### PR TITLE
[Episodes]: Add episode management with Podcast Index integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,475 +1,422 @@
-# Podcast Player API - Implementation TODO
+# Podcast Player API - Audio Processing Architecture Implementation
 
 ## Overview
-This document contains the complete implementation roadmap broken down into actionable tasks. Each phase builds upon the previous one, creating a working system incrementally.
+This document outlines the implementation plan for a comprehensive audio processing architecture with real-time streaming, metadata extraction, and segment classification capabilities.
 
-## Phase 1: Foundation & Core Structure ⚙️
+## Current Status ✅
+- [x] Basic project structure with internal packages
+- [x] Configuration management with Viper
+- [x] CLI structure with Cobra
+- [x] Podcast Index API client for search
+- [x] Basic HTTP server with Gin
+- [x] Database models defined (Podcast, Episode, PlaybackState)
 
-### Project Setup
-- [x] Create internal package structure (`internal/api`, `internal/models`, `internal/services`, `internal/database`)
-- [x] Create pkg directory for reusable packages (`pkg/config`, `pkg/ffmpeg`, `pkg/cache`)
-- [x] Set up .gitignore for Go project
-- [x] Initialize Go workspace settings
+## Phase 1: Episode Management & Storage 🎙️
 
-### Configuration Management
-- [x] Implement Viper configuration loader in `pkg/config/config.go`
-- [x] Create config struct with all settings
-- [x] Add environment variable override support
-- [x] Implement config validation
-- [x] Create config loader tests
-
-### CLI Structure
-- [x] Create `cmd/serve.go` for server command
-- [x] Update `cmd/root.go` with proper descriptions
-- [x] Add version command with build info
-- [x] Implement graceful shutdown handling
-
-### Database Layer
-- [ ] Set up GORM with SQLite driver
-- [ ] Create database connection manager
-- [ ] Implement connection pooling
-- [ ] Add database health check
-- [ ] Create base repository interface
-
-### Database Models
-- [ ] Create Podcast model with GORM tags
-- [ ] Create Episode model with relationships
-- [ ] Create AudioTag model with validations
-- [ ] Create ProcessingJob model
-- [ ] Create Waveform and Transcription models
-
-### Database Migrations
-- [x] Set up migration system (GORM AutoMigrate)
-- [ ] AutoMigrate runs on server startup
-- [ ] Create initial schema with AutoMigrate
-- [ ] Add migration hooks for data migrations if needed
-
-### HTTP Server
-- [ ] Set up Gorilla Mux router
-- [ ] Implement health check endpoint
-- [ ] Add request/response logging middleware
-- [ ] Implement panic recovery middleware
-- [ ] Add CORS middleware
-- [ ] Create server graceful shutdown
-
-### Logging
-- [ ] Set up zerolog for structured logging
-- [ ] Create logger factory
-- [ ] Add request ID middleware
-- [ ] Implement log levels from config
-- [ ] Add log rotation support
-
-### Testing Infrastructure
-- [ ] Set up testing utilities
-- [ ] Create test database helper
-- [ ] Add fixture loading
-- [ ] Create mock generators
-- [ ] Set up integration test tags
-
-## Phase 2: Podcast Index Integration 🎙️
-
-### API Client
-- [ ] Create Podcast Index client struct
-- [ ] Implement request signing (API key + secret + timestamp)
-- [ ] Add HTTP client with timeout
-- [ ] Implement retry logic with exponential backoff
-- [ ] Add circuit breaker pattern
-
-### API Methods
-- [ ] Implement SearchPodcasts method
-- [ ] Implement GetPodcastByID method
+### Episode Fetching Service
+- [ ] Create `internal/services/episodes/fetcher.go` with Podcast Index integration
 - [ ] Implement GetEpisodesByPodcastID method
-- [ ] Implement GetPodcastByFeedURL method
-- [ ] Add response parsing and validation
+- [ ] Add GetEpisodeByGUID method
+- [ ] Parse episode enclosure URLs for audio files
+- [ ] Extract episode metadata (duration, size, publish date)
 
-### Caching Layer
-- [ ] Implement in-memory cache with go-cache
-- [ ] Add cache key generation
-- [ ] Implement cache TTL from config
-- [ ] Add cache invalidation methods
-- [ ] Create cache metrics
+### Episode Repository
+- [ ] Create `internal/services/episodes/repository.go` with GORM
+- [ ] Implement CreateEpisode method
+- [ ] Add UpdateEpisode method
+- [ ] Create GetEpisodeByID method
+- [ ] Add GetEpisodesByPodcastID with pagination
 
-### Error Handling
-- [ ] Create custom error types
-- [ ] Implement error wrapping
-- [ ] Add error logging
-- [ ] Create user-friendly error messages
-- [ ] Add error recovery strategies
+### Episode Caching
+- [ ] Create `internal/services/episodes/cache.go` with in-memory caching
+- [ ] Implement TTL-based cache expiration
+- [ ] Add cache warming for popular episodes
+- [ ] Create cache invalidation methods
 
-### REST Endpoints
-- [ ] Create POST /api/v1/search endpoint
-- [ ] Create GET /api/v1/podcasts/:id endpoint
-- [ ] Create GET /api/v1/podcasts/:id/episodes endpoint
-- [ ] Add request validation
-- [ ] Implement response formatting
-
-### Testing
-- [ ] Create Podcast Index client mocks
-- [ ] Write unit tests for client methods
-- [ ] Add integration tests with mock server
-- [ ] Test cache behavior
-- [ ] Test error scenarios
-
-## Phase 3: WebSocket Infrastructure 🔌
-
-### WebSocket Server
-- [ ] Set up Gorilla WebSocket upgrader
-- [ ] Create WebSocket connection handler
-- [ ] Implement connection manager
-- [ ] Add connection pool management
-- [ ] Create connection cleanup on disconnect
-
-### Message Protocol
-- [ ] Define message structure (id, type, timestamp, payload)
-- [ ] Create message encoder/decoder
-- [ ] Implement message validation
-- [ ] Add message versioning support
-- [ ] Create message factory
-
-### Message Types
-- [ ] Define all client → server message types
-- [ ] Define all server → client message types
-- [ ] Create message handlers map
-- [ ] Implement message routing
-- [ ] Add unknown message handling
-
-### Heartbeat Mechanism
-- [ ] Implement ping/pong messages
-- [ ] Add heartbeat timer (30s)
-- [ ] Create connection health monitoring
-- [ ] Implement automatic reconnection logic
-- [ ] Add connection state tracking
-
-### Broadcasting
-- [ ] Create broadcast channel
-- [ ] Implement selective broadcasting
-- [ ] Add message queuing for offline clients
-- [ ] Create broadcast rate limiting
-- [ ] Add broadcast metrics
+### API Endpoints
+- [ ] Create GET `/api/v1/podcasts/:id/episodes` endpoint
+- [ ] Add GET `/api/v1/episodes/:id` endpoint
+- [ ] Implement pagination and filtering
+- [ ] Add response caching headers
 
 ### Testing
-- [ ] Create WebSocket test client
-- [ ] Write connection tests
-- [ ] Test message handling
-- [ ] Test heartbeat mechanism
-- [ ] Test reconnection scenarios
+- [ ] Unit tests for fetcher service
+- [ ] Repository integration tests
+- [ ] Cache behavior tests
+- [ ] API endpoint tests
 
-## Phase 4: Audio Streaming 🎵
+## Phase 2: Audio Streaming Infrastructure 🎵
 
 ### Stream Proxy Service
-- [ ] Create stream proxy handler
-- [ ] Implement HTTP client for source URLs
-- [ ] Add request forwarding logic
-- [ ] Implement response streaming
-- [ ] Add connection pooling
+- [ ] Create `internal/services/audio/stream_proxy.go`
+- [ ] Implement HTTP client for fetching audio from source URLs
+- [ ] Add connection pooling and timeout handling
+- [ ] Create stream writer with buffering
+- [ ] Implement error recovery and retry logic
 
 ### Range Request Support
-- [ ] Parse Range headers
-- [ ] Implement partial content responses (206)
-- [ ] Add Content-Range header generation
-- [ ] Handle multiple range requests
-- [ ] Add range validation
+- [ ] Parse Range headers in requests
+- [ ] Implement partial content responses (HTTP 206)
+- [ ] Generate proper Content-Range headers
+- [ ] Handle multi-part range requests
+- [ ] Add range validation and error handling
 
-### Chunked Transfer
-- [ ] Implement chunked encoding support
-- [ ] Create chunk writer
-- [ ] Add chunk size configuration
-- [ ] Handle chunk errors
-- [ ] Add chunk metrics
+### Stream Manager
+- [ ] Create `internal/services/audio/stream_manager.go`
+- [ ] Implement concurrent stream limiting
+- [ ] Add bandwidth throttling per connection
+- [ ] Create stream metrics collection
+- [ ] Implement stream cleanup on disconnect
 
-### Caching Headers
-- [ ] Add ETag generation
-- [ ] Implement If-None-Match handling
-- [ ] Add Cache-Control headers
-- [ ] Implement Last-Modified headers
-- [ ] Add cache validation
-
-### Stream Endpoint
-- [ ] Create GET /api/v1/stream/:episodeId endpoint
-- [ ] Add authorization checks
-- [ ] Implement bandwidth throttling
-- [ ] Add concurrent connection limits
-- [ ] Create stream metrics
+### Streaming Endpoint
+- [ ] Create GET `/api/v1/stream/:episodeId` endpoint
+- [ ] Add authentication/authorization checks
+- [ ] Implement proper CORS headers for audio
+- [ ] Add caching headers (ETag, Last-Modified)
+- [ ] Create stream analytics logging
 
 ### Testing
 - [ ] Test range request handling
-- [ ] Test streaming large files
-- [ ] Test connection interruption
-- [ ] Test concurrent streams
-- [ ] Load test streaming endpoint
+- [ ] Verify streaming with interruptions
+- [ ] Load test concurrent streams
+- [ ] Test bandwidth limiting
+- [ ] Verify cleanup on disconnect
 
-## Phase 5: Audio Processing Pipeline 🎚️
+## Phase 3: WebSocket Real-time Communication 🔌
+
+### WebSocket Hub
+- [ ] Create `internal/services/websocket/hub.go`
+- [ ] Implement connection registry
+- [ ] Add broadcast channel system
+- [ ] Create targeted message sending
+- [ ] Implement connection pooling
+
+### Client Handler
+- [ ] Create `internal/services/websocket/client.go`
+- [ ] Implement WebSocket upgrader
+- [ ] Add read/write pumps with goroutines
+- [ ] Create message queuing for offline clients
+- [ ] Implement connection state management
+
+### Message Protocol
+- [ ] Create `internal/services/websocket/messages.go`
+- [ ] Define message types enum
+- [ ] Implement message serialization/deserialization
+- [ ] Add message validation
+- [ ] Create message factory methods
+
+### WebSocket Endpoints
+- [ ] Create WebSocket endpoint `/api/v1/ws`
+- [ ] Implement subscription messages
+- [ ] Add unsubscribe functionality
+- [ ] Create heartbeat/ping-pong mechanism
+- [ ] Implement reconnection protocol
+
+### Testing
+- [ ] WebSocket connection tests
+- [ ] Message routing tests
+- [ ] Broadcast functionality tests
+- [ ] Reconnection scenario tests
+- [ ] Load test with many connections
+
+## Phase 4: Audio Processing Pipeline 🎚️
 
 ### Job Queue System
-- [ ] Create job queue manager
-- [ ] Implement worker pool pattern
-- [ ] Add job priority system
-- [ ] Create job persistence
-- [ ] Implement job retry logic
+- [ ] Create `internal/services/processing/job_queue.go`
+- [ ] Implement priority queue with heap
+- [ ] Add worker pool pattern
+- [ ] Create job persistence in database
+- [ ] Implement job retry with exponential backoff
 
-### FFmpeg Integration
-- [ ] Create FFmpeg wrapper service
-- [ ] Implement FFprobe metadata extraction
-- [ ] Add process timeout handling
-- [ ] Create process cleanup
-- [ ] Add FFmpeg error parsing
+### Processing Orchestrator
+- [ ] Create `internal/services/processing/processor.go`
+- [ ] Implement job scheduling logic
+- [ ] Add job status tracking
+- [ ] Create progress reporting
+- [ ] Implement job cancellation
 
 ### Metadata Extraction
-- [ ] Extract duration and bitrate
-- [ ] Parse ID3 tags
-- [ ] Extract codec information
-- [ ] Get sample rate and channels
+- [ ] Create `internal/services/audio/metadata_extractor.go`
+- [ ] Integrate FFprobe for metadata extraction
+- [ ] Extract duration, bitrate, codec info
+- [ ] Parse ID3 tags and chapter markers
 - [ ] Store metadata in database
 
-### Processing Jobs
-- [ ] Create job creation endpoint
-- [ ] Implement job status tracking
-- [ ] Add progress calculation
-- [ ] Create job cancellation
-- [ ] Add job cleanup
+### Processing Models
+- [ ] Create ProcessingJob model with status tracking
+- [ ] Add JobProgress model for progress updates
+- [ ] Create ProcessingResult model
+- [ ] Add database migrations
 
-### WebSocket Updates
-- [ ] Send processing_started message
-- [ ] Implement progress updates
-- [ ] Send processing_complete message
-- [ ] Add error notifications
-- [ ] Create status query handling
+### Processing Endpoints
+- [ ] Create POST `/api/v1/episodes/:id/process` endpoint
+- [ ] Add GET `/api/v1/jobs/:id` status endpoint
+- [ ] Implement DELETE `/api/v1/jobs/:id` cancellation
+- [ ] Create GET `/api/v1/episodes/:id/processing-status`
 
 ### Testing
-- [ ] Test metadata extraction
-- [ ] Test job queue behavior
-- [ ] Test worker pool scaling
-- [ ] Test job retry logic
-- [ ] Test progress tracking
+- [ ] Job queue behavior tests
+- [ ] Worker pool scaling tests
+- [ ] Metadata extraction tests
+- [ ] Job retry logic tests
+- [ ] Progress tracking tests
 
-## Phase 6: Waveform Generation 📊
+## Phase 5: Waveform Generation 📊
 
-### Audiowaveform Integration
-- [ ] Create audiowaveform wrapper
-- [ ] Implement waveform generation
-- [ ] Add multi-resolution support
-- [ ] Create temp file management
-- [ ] Add process monitoring
+### Waveform Generator
+- [ ] Create `internal/services/processing/waveform_generator.go`
+- [ ] Integrate audiowaveform binary
+- [ ] Implement multi-resolution generation (low, medium, high)
+- [ ] Add temporary file management
+- [ ] Create waveform data compression
 
-### Waveform Processing
-- [ ] Generate low-res waveform (fast)
-- [ ] Generate standard waveform
-- [ ] Generate high-res waveform
-- [ ] Store waveform data in database
-- [ ] Add waveform caching
-
-### Waveform Endpoint
-- [ ] Create GET /api/v1/episodes/:id/waveform endpoint
-- [ ] Add resolution query parameter
-- [ ] Implement format selection (JSON/binary)
-- [ ] Add compression support
-- [ ] Create response caching
+### Waveform Storage
+- [ ] Create Waveform model with resolution levels
+- [ ] Implement waveform data storage (JSON/binary)
+- [ ] Add waveform caching layer
+- [ ] Create cleanup for old waveforms
 
 ### Progressive Generation
-- [ ] Implement staged generation
-- [ ] Send initial low-res data
-- [ ] Update with better resolution
-- [ ] Add generation queue
-- [ ] Create priority handling
+- [ ] Generate low-res waveform first (< 2 seconds)
+- [ ] Queue medium-res generation
+- [ ] Schedule high-res for popular episodes
+- [ ] Send WebSocket updates for each level
 
-### Testing
-- [ ] Test waveform generation
-- [ ] Test different audio formats
-- [ ] Test resolution accuracy
-- [ ] Test large file handling
-- [ ] Performance benchmarks
-
-## Phase 7: Transcription Integration 🗣️
-
-### Whisper API Client
-- [ ] Create OpenAI client
-- [ ] Implement authentication
-- [ ] Add request formatting
-- [ ] Create response parsing
-- [ ] Add error handling
-
-### Audio Chunking
-- [ ] Implement file size checking
-- [ ] Create audio splitter using FFmpeg
-- [ ] Add silence detection
-- [ ] Implement chunk overlap
-- [ ] Create chunk management
-
-### Transcription Processing
-- [ ] Send audio to Whisper API
-- [ ] Handle API responses
-- [ ] Merge chunked transcriptions
-- [ ] Align timestamps
-- [ ] Store transcriptions
-
-### Cost Management
-- [ ] Implement cost tracking
-- [ ] Add usage quotas
-- [ ] Create billing alerts
-- [ ] Add cost optimization
-- [ ] Generate usage reports
-
-### Transcript Endpoint
-- [ ] Create GET /api/v1/episodes/:id/transcript endpoint
-- [ ] Add format selection (JSON/VTT/SRT)
-- [ ] Implement time range filtering
-- [ ] Add search functionality
-- [ ] Create caching layer
-
-### Testing
-- [ ] Test transcription accuracy
-- [ ] Test chunking logic
-- [ ] Test timestamp alignment
-- [ ] Test cost tracking
-- [ ] Test API error handling
-
-## Phase 8: Audio Tagging System 🏷️
-
-### Tag Management
-- [ ] Create tag CRUD operations
-- [ ] Implement tag validation
-- [ ] Add overlap detection
-- [ ] Create tag categories
-- [ ] Add tag search
-
-### Tag Endpoints
-- [ ] Create POST /api/v1/episodes/:id/tags endpoint
-- [ ] Create GET /api/v1/episodes/:id/tags endpoint
-- [ ] Create PUT /api/v1/tags/:id endpoint
-- [ ] Create DELETE /api/v1/tags/:id endpoint
-- [ ] Add batch operations
+### Waveform Endpoints
+- [ ] Create GET `/api/v1/episodes/:id/waveform` endpoint
+- [ ] Add resolution query parameter
+- [ ] Implement format selection (JSON/binary)
+- [ ] Add compression support (gzip)
 
 ### WebSocket Integration
-- [ ] Create tag_created message
-- [ ] Create tag_updated message
-- [ ] Create tag_deleted message
-- [ ] Add real-time sync
-- [ ] Implement conflict resolution
-
-### Tag Features
-- [ ] Add tag colors
-- [ ] Implement tag categories
-- [ ] Create tag templates
-- [ ] Add tag export
-- [ ] Implement tag sharing
+- [ ] Send waveform_ready message
+- [ ] Include resolution level in updates
+- [ ] Add progressive enhancement updates
+- [ ] Implement data chunking for large waveforms
 
 ### Testing
-- [ ] Test CRUD operations
-- [ ] Test overlap validation
-- [ ] Test time range queries
-- [ ] Test WebSocket updates
-- [ ] Test data integrity
+- [ ] Waveform generation accuracy tests
+- [ ] Multi-resolution tests
+- [ ] Large file handling tests
+- [ ] WebSocket update tests
+- [ ] Performance benchmarks
 
-## Phase 9: Optimization & Polish 🚀
+## Phase 6: Audio Segment Classification 🏷️
 
-### Performance Optimization
-- [ ] Add database query optimization
-- [ ] Implement connection pooling
-- [ ] Add response compression
-- [ ] Create asset minification
-- [ ] Optimize memory usage
+### Segment Analyzer
+- [ ] Create `internal/services/processing/segment_analyzer.go`
+- [ ] Implement silence detection algorithm
+- [ ] Add volume normalization analysis
+- [ ] Create frequency analysis for music/speech detection
 
-### Error Handling
-- [ ] Implement comprehensive error handling
-- [ ] Add error recovery strategies
-- [ ] Create error reporting
-- [ ] Add user-friendly messages
-- [ ] Implement error analytics
+### Classification Engine
+- [ ] Create `internal/services/processing/classifier.go`
+- [ ] Implement advertisement detection using audio fingerprinting
+- [ ] Add intro/outro detection patterns
+- [ ] Create chapter boundary detection
+- [ ] Implement confidence scoring
 
-### Monitoring
-- [ ] Add Prometheus metrics
-- [ ] Create health dashboards
-- [ ] Implement alerting rules
-- [ ] Add performance tracking
-- [ ] Create usage analytics
+### Segment Models
+- [ ] Create AudioSegment model
+- [ ] Add SegmentType enum (content, ad, music, silence, intro, outro)
+- [ ] Create SegmentConfidence model
+- [ ] Add database migrations
+
+### ML Integration (Future)
+- [ ] Prepare interface for ML model integration
+- [ ] Create training data collection mechanism
+- [ ] Add model versioning support
+- [ ] Implement A/B testing framework
+
+### Segment Endpoints
+- [ ] Create GET `/api/v1/episodes/:id/segments` endpoint
+- [ ] Add POST `/api/v1/segments/:id/feedback` for corrections
+- [ ] Implement segment export functionality
+
+### WebSocket Updates
+- [ ] Send segment_detected message
+- [ ] Include confidence scores
+- [ ] Add segment type and timestamps
+- [ ] Implement incremental updates
+
+### Testing
+- [ ] Silence detection accuracy tests
+- [ ] Classification accuracy tests
+- [ ] Performance tests with long audio
+- [ ] WebSocket notification tests
+
+## Phase 7: Client Synchronization Protocol 🔄
+
+### Synchronization Service
+- [ ] Create `internal/services/sync/coordinator.go`
+- [ ] Implement timestamp-based sync protocol
+- [ ] Add client state tracking
+- [ ] Create sync message queue
+
+### Progressive Enhancement Flow
+- [ ] Immediate: Return episode metadata and stream URL
+- [ ] 0-2 seconds: Send low-res waveform via WebSocket
+- [ ] 2-5 seconds: Send initial segment classifications
+- [ ] 5-10 seconds: Send medium-res waveform
+- [ ] 10-30 seconds: Send refined segments with high confidence
+- [ ] 30-60 seconds: Send high-res waveform if requested
+
+### Client State Management
+- [ ] Track client playback position
+- [ ] Store client preferences
+- [ ] Implement state recovery on reconnect
+- [ ] Add multi-device sync support
+
+### Sync Protocol Messages
+```json
+{
+  "type": "sync_state",
+  "episodeId": "string",
+  "position": 0,
+  "speed": 1.0,
+  "volume": 1.0
+}
+```
+
+### Testing
+- [ ] Sync accuracy tests
+- [ ] Reconnection state recovery tests
+- [ ] Multi-client sync tests
+- [ ] Progressive enhancement tests
+
+## Phase 8: Performance & Optimization 🚀
+
+### Database Optimization
+- [ ] Add database indexes for common queries
+- [ ] Implement query result caching
+- [ ] Add connection pooling tuning
+- [ ] Create database vacuum schedule
+
+### Caching Strategy
+- [ ] Implement Redis for distributed caching
+- [ ] Add CDN integration for audio files
+- [ ] Create edge caching for waveforms
+- [ ] Implement cache warming strategies
+
+### Performance Monitoring
+- [ ] Add Prometheus metrics collection
+- [ ] Create Grafana dashboards
+- [ ] Implement distributed tracing
+- [ ] Add performance benchmarks
+
+### Resource Management
+- [ ] Implement rate limiting per client
+- [ ] Add request prioritization
+- [ ] Create resource pools for expensive operations
+- [ ] Implement circuit breakers
+
+### Testing
+- [ ] Load testing with k6 or similar
+- [ ] Memory leak detection
+- [ ] CPU profiling
+- [ ] Concurrent user testing
+
+## Phase 9: Production Readiness 🛡️
 
 ### Security
-- [ ] Add rate limiting
-- [ ] Implement request validation
-- [ ] Add SQL injection prevention
-- [ ] Create security headers
-- [ ] Implement API authentication
+- [ ] Implement API key authentication
+- [ ] Add JWT token support
+- [ ] Create rate limiting by API key
+- [ ] Implement DDoS protection
+- [ ] Add input sanitization
+
+### Error Handling
+- [ ] Create comprehensive error types
+- [ ] Implement error recovery strategies
+- [ ] Add error tracking (Sentry integration)
+- [ ] Create user-friendly error messages
+
+### Deployment
+- [ ] Create production Dockerfile
+- [ ] Add Kubernetes manifests
+- [ ] Implement health checks
+- [ ] Create deployment scripts
+- [ ] Add rollback procedures
 
 ### Documentation
-- [ ] Complete API documentation
-- [ ] Create deployment guide
+- [ ] Complete API documentation with OpenAPI
+- [ ] Create architecture diagrams
+- [ ] Write deployment guide
 - [ ] Add troubleshooting guide
 - [ ] Create performance tuning guide
-- [ ] Add architecture diagrams
 
-### Testing
-- [ ] Achieve 80% code coverage
-- [ ] Add load testing
-- [ ] Create chaos testing
-- [ ] Add security testing
-- [ ] Implement E2E tests
+### Monitoring & Alerting
+- [ ] Set up application monitoring
+- [ ] Create alert rules
+- [ ] Implement log aggregation
+- [ ] Add uptime monitoring
+- [ ] Create incident response playbooks
 
-## Deployment & DevOps 🛠️
+## Success Metrics 📊
 
-### Containerization
-- [ ] Create Dockerfile
-- [ ] Add multi-stage build
-- [ ] Create docker-compose.yml
-- [ ] Add health checks
-- [ ] Optimize image size
+### Performance Targets
+- [ ] < 500ms stream start latency
+- [ ] < 2s for low-res waveform generation
+- [ ] < 10s for full waveform generation (1hr episode)
+- [ ] < 100ms WebSocket message delivery
+- [ ] Support 1000+ concurrent streams
 
-### CI/CD Pipeline
-- [ ] Set up GitHub Actions
-- [ ] Add automated testing
-- [ ] Create build pipeline
-- [ ] Add deployment automation
-- [ ] Implement rollback strategy
+### Quality Targets
+- [ ] 99.9% uptime
+- [ ] < 0.1% stream failure rate
+- [ ] > 85% segment classification accuracy
+- [ ] < 1% audio artifact rate
+- [ ] Zero data loss for processing jobs
 
-### Monitoring Setup
-- [ ] Deploy Prometheus
-- [ ] Set up Grafana dashboards
-- [ ] Add log aggregation
-- [ ] Create alerts
-- [ ] Implement tracing
+### User Experience Targets
+- [ ] Instant playback start
+- [ ] Seamless seeking with range requests
+- [ ] Real-time waveform updates
+- [ ] Accurate ad detection
+- [ ] Smooth multi-device sync
 
-### Production Readiness
-- [ ] Create production config
-- [ ] Add secrets management
-- [ ] Implement backup strategy
-- [ ] Create disaster recovery plan
-- [ ] Add scaling strategy
+## Next Immediate Steps 🎯
 
-## Future Enhancements 🔮
+1. **Week 1**: Complete Episode Management (Phase 1)
+   - Set up episode fetching from Podcast Index
+   - Create database repository
+   - Add API endpoints
 
-### Features
-- [ ] Multi-user support
-- [ ] Playlist management
-- [ ] RSS feed subscriptions
-- [ ] Offline support
-- [ ] Social features
+2. **Week 2**: Implement Audio Streaming (Phase 2)
+   - Create stream proxy service
+   - Add range request support
+   - Test with real podcast episodes
 
-### Technical
-- [ ] GraphQL API
-- [ ] Real-time collaboration
-- [ ] Machine learning recommendations
-- [ ] Advanced search with Elasticsearch
-- [ ] Kubernetes deployment
+3. **Week 3**: Add WebSocket Infrastructure (Phase 3)
+   - Set up WebSocket hub
+   - Define message protocol
+   - Test real-time updates
 
-## Success Criteria ✅
+4. **Week 4**: Build Processing Pipeline (Phase 4)
+   - Create job queue system
+   - Add metadata extraction
+   - Implement progress tracking
 
-### Phase Completion
-- All tests passing
-- Documentation updated
-- Code reviewed
-- Performance benchmarks met
-- No critical bugs
+## Technical Decisions 📝
 
-### Project Success
-- < 500ms stream start time
-- < 10s waveform generation for 1hr episode
-- < 2min transcription for 1hr episode
-- 99.9% uptime
-- < 100ms WebSocket latency
+### Streaming Architecture
+- **Direct Proxy**: Stream directly from source URLs without caching
+- **Range Support**: Enable seeking without downloading entire file
+- **Adaptive Bitrate**: Future enhancement for bandwidth optimization
 
-## Notes
+### Processing Architecture
+- **Job Queue**: Async processing with priority support
+- **Progressive Enhancement**: Deliver results as they become available
+- **Graceful Degradation**: System works without all features
 
-- Each task should have associated tests
-- Documentation should be updated with each phase
-- Performance should be monitored throughout
-- Security should be considered at every step
-- User feedback should guide prioritization
+### Synchronization Strategy
+- **Client-driven**: Client maintains source of truth for playback position
+- **Server-assisted**: Server provides metadata and sync coordination
+- **Timestamp-based**: All updates include timestamps for correlation
+
+### Technology Stack
+- **Streaming**: HTTP proxy with range request support
+- **WebSocket**: Gorilla WebSocket for real-time updates
+- **Processing**: FFmpeg for audio analysis
+- **Waveform**: Audiowaveform for visualization data
+- **Queue**: In-memory priority queue with database persistence

--- a/internal/api/handlers/episodes.go
+++ b/internal/api/handlers/episodes.go
@@ -1,0 +1,250 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/killallgit/player-api/internal/services/episodes"
+)
+
+type EpisodeHandler struct {
+	fetcher    *episodes.Fetcher
+	repository *episodes.CachedRepository
+}
+
+func NewEpisodeHandler(fetcher *episodes.Fetcher, repository *episodes.CachedRepository) *EpisodeHandler {
+	return &EpisodeHandler{
+		fetcher:    fetcher,
+		repository: repository,
+	}
+}
+
+func (h *EpisodeHandler) GetEpisodesByPodcastID(c *gin.Context) {
+	podcastIDStr := c.Param("id")
+	podcastID, err := strconv.ParseUint(podcastIDStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid podcast ID",
+		})
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+
+	episodes, total, err := h.repository.GetEpisodesByPodcastID(c.Request.Context(), uint(podcastID), page, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to fetch episodes",
+		})
+		return
+	}
+
+	totalPages := (int(total) + limit - 1) / limit
+
+	c.JSON(http.StatusOK, gin.H{
+		"episodes": episodes,
+		"pagination": gin.H{
+			"page":        page,
+			"limit":       limit,
+			"total":       total,
+			"total_pages": totalPages,
+			"has_next":    page < totalPages,
+			"has_prev":    page > 1,
+		},
+	})
+}
+
+func (h *EpisodeHandler) GetEpisodeByID(c *gin.Context) {
+	episodeIDStr := c.Param("id")
+	episodeID, err := strconv.ParseUint(episodeIDStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid episode ID",
+		})
+		return
+	}
+
+	episode, err := h.repository.GetEpisodeByID(c.Request.Context(), uint(episodeID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Episode not found",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, episode)
+}
+
+func (h *EpisodeHandler) SyncEpisodesFromPodcastIndex(c *gin.Context) {
+	podcastIDStr := c.Param("id")
+	podcastID, err := strconv.ParseInt(podcastIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid podcast ID",
+		})
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	if limit < 1 || limit > 200 {
+		limit = 50
+	}
+
+	fetchedEpisodes, err := h.fetcher.GetEpisodesByPodcastID(c.Request.Context(), podcastID, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to fetch episodes from Podcast Index",
+		})
+		return
+	}
+
+	var syncedCount int
+	var errors []string
+
+	for _, episode := range fetchedEpisodes {
+		episode.PodcastID = uint(podcastID)
+		
+		existing, _ := h.repository.GetEpisodeByGUID(c.Request.Context(), episode.GUID)
+		if existing != nil {
+			episode.ID = existing.ID
+			episode.Played = existing.Played
+			episode.Position = existing.Position
+			err = h.repository.UpdateEpisode(c.Request.Context(), &episode)
+		} else {
+			err = h.repository.CreateEpisode(c.Request.Context(), &episode)
+		}
+
+		if err != nil {
+			errors = append(errors, err.Error())
+		} else {
+			syncedCount++
+		}
+	}
+
+	response := gin.H{
+		"synced":       syncedCount,
+		"total":        len(fetchedEpisodes),
+		"podcast_id":   podcastID,
+		"synced_at":    time.Now(),
+	}
+
+	if len(errors) > 0 {
+		response["errors"] = errors
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (h *EpisodeHandler) UpdatePlaybackState(c *gin.Context) {
+	episodeIDStr := c.Param("id")
+	episodeID, err := strconv.ParseUint(episodeIDStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid episode ID",
+		})
+		return
+	}
+
+	var request struct {
+		Position int  `json:"position"`
+		Played   bool `json:"played"`
+	}
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
+	episode, err := h.repository.GetEpisodeByID(c.Request.Context(), uint(episodeID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Episode not found",
+		})
+		return
+	}
+
+	episode.Position = request.Position
+	episode.Played = request.Played
+
+	if err := h.repository.UpdateEpisode(c.Request.Context(), episode); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to update playback state",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Playback state updated",
+		"episode":  episode,
+	})
+}
+
+func (h *EpisodeHandler) GetEpisodeMetadata(c *gin.Context) {
+	episodeIDStr := c.Param("id")
+	episodeID, err := strconv.ParseUint(episodeIDStr, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid episode ID",
+		})
+		return
+	}
+
+	episode, err := h.repository.GetEpisodeByID(c.Request.Context(), uint(episodeID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Episode not found",
+		})
+		return
+	}
+
+	metadata, err := h.fetcher.GetEpisodeMetadata(c.Request.Context(), episode.AudioURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to fetch metadata",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"episode":  episode,
+		"metadata": metadata,
+	})
+}
+
+func (h *EpisodeHandler) SearchEpisodes(c *gin.Context) {
+	var request struct {
+		Query     string `json:"query" binding:"required"`
+		PodcastID uint   `json:"podcast_id,omitempty"`
+		Limit     int    `json:"limit,omitempty"`
+	}
+
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid request body",
+		})
+		return
+	}
+
+	if request.Limit == 0 {
+		request.Limit = 20
+	} else if request.Limit > 100 {
+		request.Limit = 100
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Episode search not yet implemented",
+		"query":   request.Query,
+	})
+}

--- a/internal/services/episodes/cache.go
+++ b/internal/services/episodes/cache.go
@@ -1,0 +1,244 @@
+package episodes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/killallgit/player-api/internal/models"
+)
+
+type Cache struct {
+	episodes map[string]*cacheEntry
+	mu       sync.RWMutex
+	ttl      time.Duration
+}
+
+type cacheEntry struct {
+	episode   *models.Episode
+	episodes  []models.Episode
+	total     int64
+	expiresAt time.Time
+}
+
+func NewCache(ttl time.Duration) *Cache {
+	cache := &Cache{
+		episodes: make(map[string]*cacheEntry),
+		ttl:      ttl,
+	}
+	
+	go cache.cleanupExpired()
+	
+	return cache
+}
+
+func (c *Cache) GetEpisode(key string) (*models.Episode, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	
+	entry, exists := c.episodes[key]
+	if !exists || entry.expiresAt.Before(time.Now()) {
+		return nil, false
+	}
+	
+	return entry.episode, true
+}
+
+func (c *Cache) SetEpisode(key string, episode *models.Episode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	c.episodes[key] = &cacheEntry{
+		episode:   episode,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+func (c *Cache) GetEpisodeList(key string) ([]models.Episode, int64, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	
+	entry, exists := c.episodes[key]
+	if !exists || entry.expiresAt.Before(time.Now()) {
+		return nil, 0, false
+	}
+	
+	return entry.episodes, entry.total, true
+}
+
+func (c *Cache) SetEpisodeList(key string, episodes []models.Episode, total int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	c.episodes[key] = &cacheEntry{
+		episodes:  episodes,
+		total:     total,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+func (c *Cache) Invalidate(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	delete(c.episodes, key)
+}
+
+func (c *Cache) InvalidatePattern(pattern string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	for key := range c.episodes {
+		if matched, _ := matchPattern(pattern, key); matched {
+			delete(c.episodes, key)
+		}
+	}
+}
+
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	
+	c.episodes = make(map[string]*cacheEntry)
+}
+
+func (c *Cache) cleanupExpired() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	
+	for range ticker.C {
+		c.mu.Lock()
+		now := time.Now()
+		for key, entry := range c.episodes {
+			if entry.expiresAt.Before(now) {
+				delete(c.episodes, key)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+func (c *Cache) WarmCache(ctx context.Context, popularEpisodes []models.Episode) {
+	for _, episode := range popularEpisodes {
+		key := fmt.Sprintf("episode:id:%d", episode.ID)
+		c.SetEpisode(key, &episode)
+		
+		if episode.GUID != "" {
+			guidKey := fmt.Sprintf("episode:guid:%s", episode.GUID)
+			c.SetEpisode(guidKey, &episode)
+		}
+	}
+}
+
+func matchPattern(pattern, str string) (bool, error) {
+	if pattern == "*" {
+		return true, nil
+	}
+	
+	if len(pattern) > 0 && pattern[len(pattern)-1] == '*' {
+		prefix := pattern[:len(pattern)-1]
+		return len(str) >= len(prefix) && str[:len(prefix)] == prefix, nil
+	}
+	
+	return pattern == str, nil
+}
+
+type CachedRepository struct {
+	repo  *Repository
+	cache *Cache
+}
+
+func NewCachedRepository(repo *Repository, cache *Cache) *CachedRepository {
+	return &CachedRepository{
+		repo:  repo,
+		cache: cache,
+	}
+}
+
+func (cr *CachedRepository) GetEpisodeByID(ctx context.Context, id uint) (*models.Episode, error) {
+	key := fmt.Sprintf("episode:id:%d", id)
+	
+	if episode, found := cr.cache.GetEpisode(key); found {
+		return episode, nil
+	}
+	
+	episode, err := cr.repo.GetEpisodeByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	
+	cr.cache.SetEpisode(key, episode)
+	return episode, nil
+}
+
+func (cr *CachedRepository) GetEpisodeByGUID(ctx context.Context, guid string) (*models.Episode, error) {
+	key := fmt.Sprintf("episode:guid:%s", guid)
+	
+	if episode, found := cr.cache.GetEpisode(key); found {
+		return episode, nil
+	}
+	
+	episode, err := cr.repo.GetEpisodeByGUID(ctx, guid)
+	if err != nil {
+		return nil, err
+	}
+	
+	cr.cache.SetEpisode(key, episode)
+	return episode, nil
+}
+
+func (cr *CachedRepository) GetEpisodesByPodcastID(ctx context.Context, podcastID uint, page, limit int) ([]models.Episode, int64, error) {
+	key := fmt.Sprintf("episodes:podcast:%d:page:%d:limit:%d", podcastID, page, limit)
+	
+	if episodes, total, found := cr.cache.GetEpisodeList(key); found {
+		return episodes, total, nil
+	}
+	
+	episodes, total, err := cr.repo.GetEpisodesByPodcastID(ctx, podcastID, page, limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	
+	cr.cache.SetEpisodeList(key, episodes, total)
+	return episodes, total, nil
+}
+
+func (cr *CachedRepository) CreateEpisode(ctx context.Context, episode *models.Episode) error {
+	err := cr.repo.CreateEpisode(ctx, episode)
+	if err != nil {
+		return err
+	}
+	
+	cr.cache.InvalidatePattern(fmt.Sprintf("episodes:podcast:%d:*", episode.PodcastID))
+	return nil
+}
+
+func (cr *CachedRepository) UpdateEpisode(ctx context.Context, episode *models.Episode) error {
+	err := cr.repo.UpdateEpisode(ctx, episode)
+	if err != nil {
+		return err
+	}
+	
+	cr.cache.Invalidate(fmt.Sprintf("episode:id:%d", episode.ID))
+	cr.cache.Invalidate(fmt.Sprintf("episode:guid:%s", episode.GUID))
+	cr.cache.InvalidatePattern(fmt.Sprintf("episodes:podcast:%d:*", episode.PodcastID))
+	return nil
+}
+
+func (cr *CachedRepository) DeleteEpisode(ctx context.Context, id uint) error {
+	episode, err := cr.repo.GetEpisodeByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	
+	err = cr.repo.DeleteEpisode(ctx, id)
+	if err != nil {
+		return err
+	}
+	
+	cr.cache.Invalidate(fmt.Sprintf("episode:id:%d", id))
+	cr.cache.Invalidate(fmt.Sprintf("episode:guid:%s", episode.GUID))
+	cr.cache.InvalidatePattern(fmt.Sprintf("episodes:podcast:%d:*", episode.PodcastID))
+	return nil
+}

--- a/internal/services/episodes/fetcher.go
+++ b/internal/services/episodes/fetcher.go
@@ -1,0 +1,232 @@
+package episodes
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/killallgit/player-api/internal/models"
+	"github.com/killallgit/player-api/pkg/config"
+)
+
+type Fetcher struct {
+	apiKey    string
+	apiSecret string
+	apiURL    string
+	client    *http.Client
+}
+
+func NewFetcher(cfg *config.Config) *Fetcher {
+	return &Fetcher{
+		apiKey:    cfg.PodcastIndex.APIKey,
+		apiSecret: cfg.PodcastIndex.APISecret,
+		apiURL:    cfg.PodcastIndex.BaseURL,
+		client: &http.Client{
+			Timeout: cfg.PodcastIndex.Timeout,
+		},
+	}
+}
+
+func (f *Fetcher) GetEpisodesByPodcastID(ctx context.Context, podcastID int64, limit int) ([]models.Episode, error) {
+	endpoint := fmt.Sprintf("%s/episodes/byfeedid", f.apiURL)
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Add("id", strconv.FormatInt(podcastID, 10))
+	if limit > 0 {
+		q.Add("max", strconv.Itoa(limit))
+	}
+	req.URL.RawQuery = q.Encode()
+
+	f.setAuthHeaders(req)
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Status      string `json:"status"`
+		Description string `json:"description"`
+		Items       []struct {
+			ID              int64  `json:"id"`
+			Title           string `json:"title"`
+			Description     string `json:"description"`
+			EnclosureURL    string `json:"enclosureUrl"`
+			EnclosureLength int    `json:"enclosureLength"`
+			Duration        int    `json:"duration"`
+			DatePublished   int64  `json:"datePublished"`
+			GUID            string `json:"guid"`
+			Link            string `json:"link"`
+			Image           string `json:"image"`
+			FeedID          int64  `json:"feedId"`
+		} `json:"items"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Status != "true" {
+		return nil, fmt.Errorf("API error: %s", result.Description)
+	}
+
+	episodes := make([]models.Episode, 0, len(result.Items))
+	for _, item := range result.Items {
+		episode := models.Episode{
+			Title:       item.Title,
+			Description: item.Description,
+			AudioURL:    item.EnclosureURL,
+			Duration:    item.Duration,
+			GUID:        item.GUID,
+		}
+		
+		if item.DatePublished > 0 {
+			episode.PublishedAt = time.Unix(item.DatePublished, 0)
+		}
+		
+		episodes = append(episodes, episode)
+	}
+
+	return episodes, nil
+}
+
+func (f *Fetcher) GetEpisodeByGUID(ctx context.Context, guid string) (*models.Episode, error) {
+	endpoint := fmt.Sprintf("%s/episodes/byguid", f.apiURL)
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Add("guid", guid)
+	req.URL.RawQuery = q.Encode()
+
+	f.setAuthHeaders(req)
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Status      string `json:"status"`
+		Description string `json:"description"`
+		Episode     struct {
+			ID              int64  `json:"id"`
+			Title           string `json:"title"`
+			Description     string `json:"description"`
+			EnclosureURL    string `json:"enclosureUrl"`
+			EnclosureLength int    `json:"enclosureLength"`
+			Duration        int    `json:"duration"`
+			DatePublished   int64  `json:"datePublished"`
+			GUID            string `json:"guid"`
+			Link            string `json:"link"`
+			Image           string `json:"image"`
+			FeedID          int64  `json:"feedId"`
+		} `json:"episode"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Status != "true" {
+		return nil, fmt.Errorf("API error: %s", result.Description)
+	}
+
+	episode := &models.Episode{
+		Title:       result.Episode.Title,
+		Description: result.Episode.Description,
+		AudioURL:    result.Episode.EnclosureURL,
+		Duration:    result.Episode.Duration,
+		GUID:        result.Episode.GUID,
+	}
+	
+	if result.Episode.DatePublished > 0 {
+		episode.PublishedAt = time.Unix(result.Episode.DatePublished, 0)
+	}
+
+	return episode, nil
+}
+
+func (f *Fetcher) setAuthHeaders(req *http.Request) {
+	apiTime := strconv.FormatInt(time.Now().Unix(), 10)
+	authString := f.apiKey + f.apiSecret + apiTime
+	hash := sha1.Sum([]byte(authString))
+	hashString := fmt.Sprintf("%x", hash)
+
+	req.Header.Set("X-Auth-Date", apiTime)
+	req.Header.Set("X-Auth-Key", f.apiKey)
+	req.Header.Set("Authorization", hashString)
+	req.Header.Set("User-Agent", "PodcastPlayerAPI/1.0")
+}
+
+func (f *Fetcher) GetEpisodeMetadata(ctx context.Context, episodeURL string) (*EpisodeMetadata, error) {
+	parsedURL, err := url.Parse(episodeURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing episode URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "HEAD", episodeURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating HEAD request: %w", err)
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing HEAD request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	metadata := &EpisodeMetadata{
+		URL:         episodeURL,
+		ContentType: resp.Header.Get("Content-Type"),
+		FileName:    parsedURL.Path[len(parsedURL.Path)-1:],
+	}
+
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		if size, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+			metadata.Size = size
+		}
+	}
+
+	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
+		if t, err := time.Parse(http.TimeFormat, lastModified); err == nil {
+			metadata.LastModified = t
+		}
+	}
+
+	return metadata, nil
+}
+
+type EpisodeMetadata struct {
+	URL          string
+	ContentType  string
+	Size         int64
+	LastModified time.Time
+	FileName     string
+}

--- a/internal/services/episodes/fetcher_test.go
+++ b/internal/services/episodes/fetcher_test.go
@@ -1,0 +1,202 @@
+package episodes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/killallgit/player-api/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetcher_GetEpisodesByPodcastID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/1.0/episodes/byfeedid", r.URL.Path)
+		assert.Equal(t, "123", r.URL.Query().Get("id"))
+		assert.Equal(t, "10", r.URL.Query().Get("max"))
+		
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"status": "true",
+			"items": [
+				{
+					"id": 1,
+					"title": "Episode 1",
+					"description": "First episode",
+					"enclosureUrl": "https://example.com/episode1.mp3",
+					"duration": 3600,
+					"datePublished": 1609459200,
+					"guid": "guid-1"
+				},
+				{
+					"id": 2,
+					"title": "Episode 2",
+					"description": "Second episode",
+					"enclosureUrl": "https://example.com/episode2.mp3",
+					"duration": 1800,
+					"datePublished": 1609545600,
+					"guid": "guid-2"
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		PodcastIndex: config.PodcastIndexConfig{
+			APIKey:    "test-key",
+			APISecret: "test-secret",
+			BaseURL:    server.URL + "/api/1.0",
+			Timeout:   5 * time.Second,
+		},
+	}
+
+	fetcher := NewFetcher(cfg)
+	episodes, err := fetcher.GetEpisodesByPodcastID(context.Background(), 123, 10)
+
+	require.NoError(t, err)
+	assert.Len(t, episodes, 2)
+
+	assert.Equal(t, "Episode 1", episodes[0].Title)
+	assert.Equal(t, "First episode", episodes[0].Description)
+	assert.Equal(t, "https://example.com/episode1.mp3", episodes[0].AudioURL)
+	assert.Equal(t, 3600, episodes[0].Duration)
+	assert.Equal(t, "guid-1", episodes[0].GUID)
+	assert.Equal(t, time.Unix(1609459200, 0), episodes[0].PublishedAt)
+
+	assert.Equal(t, "Episode 2", episodes[1].Title)
+	assert.Equal(t, "https://example.com/episode2.mp3", episodes[1].AudioURL)
+}
+
+func TestFetcher_GetEpisodeByGUID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/1.0/episodes/byguid", r.URL.Path)
+		assert.Equal(t, "test-guid", r.URL.Query().Get("guid"))
+		
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"status": "true",
+			"episode": {
+				"id": 1,
+				"title": "Test Episode",
+				"description": "Test description",
+				"enclosureUrl": "https://example.com/test.mp3",
+				"duration": 2400,
+				"datePublished": 1609459200,
+				"guid": "test-guid"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		PodcastIndex: config.PodcastIndexConfig{
+			APIKey:    "test-key",
+			APISecret: "test-secret",
+			BaseURL:    server.URL + "/api/1.0",
+			Timeout:   5 * time.Second,
+		},
+	}
+
+	fetcher := NewFetcher(cfg)
+	episode, err := fetcher.GetEpisodeByGUID(context.Background(), "test-guid")
+
+	require.NoError(t, err)
+	require.NotNil(t, episode)
+
+	assert.Equal(t, "Test Episode", episode.Title)
+	assert.Equal(t, "Test description", episode.Description)
+	assert.Equal(t, "https://example.com/test.mp3", episode.AudioURL)
+	assert.Equal(t, 2400, episode.Duration)
+	assert.Equal(t, "test-guid", episode.GUID)
+	assert.Equal(t, time.Unix(1609459200, 0), episode.PublishedAt)
+}
+
+func TestFetcher_GetEpisodeMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "HEAD", r.Method)
+		
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Content-Length", "5242880")
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		PodcastIndex: config.PodcastIndexConfig{
+			APIKey:    "test-key",
+			APISecret: "test-secret",
+			BaseURL:    "https://api.podcastindex.org/api/1.0",
+			Timeout:   5 * time.Second,
+		},
+	}
+
+	fetcher := NewFetcher(cfg)
+	metadata, err := fetcher.GetEpisodeMetadata(context.Background(), server.URL+"/episode.mp3")
+
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+
+	assert.Equal(t, server.URL+"/episode.mp3", metadata.URL)
+	assert.Equal(t, "audio/mpeg", metadata.ContentType)
+	assert.Equal(t, int64(5242880), metadata.Size)
+	assert.Equal(t, "Mon, 02 Jan 2006 15:04:05 GMT", metadata.LastModified.Format(http.TimeFormat))
+}
+
+func TestFetcher_ErrorHandling(t *testing.T) {
+	t.Run("API returns error status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"status": "false",
+				"description": "Invalid API key"
+			}`))
+		}))
+		defer server.Close()
+
+		cfg := &config.Config{
+			PodcastIndex: config.PodcastIndexConfig{
+				APIKey:    "invalid-key",
+				APISecret: "invalid-secret",
+				BaseURL:    server.URL + "/api/1.0",
+				Timeout:   5 * time.Second,
+			},
+		}
+
+		fetcher := NewFetcher(cfg)
+		_, err := fetcher.GetEpisodesByPodcastID(context.Background(), 123, 10)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid API key")
+	})
+
+	t.Run("HTTP error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal Server Error"))
+		}))
+		defer server.Close()
+
+		cfg := &config.Config{
+			PodcastIndex: config.PodcastIndexConfig{
+				APIKey:    "test-key",
+				APISecret: "test-secret",
+				BaseURL:    server.URL + "/api/1.0",
+				Timeout:   5 * time.Second,
+			},
+		}
+
+		fetcher := NewFetcher(cfg)
+		_, err := fetcher.GetEpisodesByPodcastID(context.Background(), 123, 10)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "API returned status 500")
+	})
+}

--- a/internal/services/episodes/repository.go
+++ b/internal/services/episodes/repository.go
@@ -1,0 +1,155 @@
+package episodes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/killallgit/player-api/internal/models"
+	"gorm.io/gorm"
+)
+
+type Repository struct {
+	db *gorm.DB
+}
+
+func NewRepository(db *gorm.DB) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) CreateEpisode(ctx context.Context, episode *models.Episode) error {
+	if err := r.db.WithContext(ctx).Create(episode).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return fmt.Errorf("episode with GUID %s already exists", episode.GUID)
+		}
+		return fmt.Errorf("creating episode: %w", err)
+	}
+	return nil
+}
+
+func (r *Repository) UpdateEpisode(ctx context.Context, episode *models.Episode) error {
+	result := r.db.WithContext(ctx).Save(episode)
+	if result.Error != nil {
+		return fmt.Errorf("updating episode: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("episode not found")
+	}
+	return nil
+}
+
+func (r *Repository) GetEpisodeByID(ctx context.Context, id uint) (*models.Episode, error) {
+	var episode models.Episode
+	if err := r.db.WithContext(ctx).First(&episode, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("episode with ID %d not found", id)
+		}
+		return nil, fmt.Errorf("getting episode: %w", err)
+	}
+	return &episode, nil
+}
+
+func (r *Repository) GetEpisodeByGUID(ctx context.Context, guid string) (*models.Episode, error) {
+	var episode models.Episode
+	if err := r.db.WithContext(ctx).Where("guid = ?", guid).First(&episode).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("episode with GUID %s not found", guid)
+		}
+		return nil, fmt.Errorf("getting episode: %w", err)
+	}
+	return &episode, nil
+}
+
+func (r *Repository) GetEpisodesByPodcastID(ctx context.Context, podcastID uint, page, limit int) ([]models.Episode, int64, error) {
+	var episodes []models.Episode
+	var total int64
+
+	offset := (page - 1) * limit
+
+	query := r.db.WithContext(ctx).Model(&models.Episode{}).Where("podcast_id = ?", podcastID)
+	
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("counting episodes: %w", err)
+	}
+
+	if err := query.
+		Order("published_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&episodes).Error; err != nil {
+		return nil, 0, fmt.Errorf("getting episodes: %w", err)
+	}
+
+	return episodes, total, nil
+}
+
+func (r *Repository) GetRecentEpisodes(ctx context.Context, limit int) ([]models.Episode, error) {
+	var episodes []models.Episode
+	
+	if err := r.db.WithContext(ctx).
+		Order("published_at DESC").
+		Limit(limit).
+		Find(&episodes).Error; err != nil {
+		return nil, fmt.Errorf("getting recent episodes: %w", err)
+	}
+	
+	return episodes, nil
+}
+
+func (r *Repository) DeleteEpisode(ctx context.Context, id uint) error {
+	result := r.db.WithContext(ctx).Delete(&models.Episode{}, id)
+	if result.Error != nil {
+		return fmt.Errorf("deleting episode: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("episode with ID %d not found", id)
+	}
+	return nil
+}
+
+func (r *Repository) UpsertEpisode(ctx context.Context, episode *models.Episode) error {
+	var existing models.Episode
+	err := r.db.WithContext(ctx).Where("guid = ?", episode.GUID).First(&existing).Error
+	
+	if err == nil {
+		episode.ID = existing.ID
+		episode.CreatedAt = existing.CreatedAt
+		return r.UpdateEpisode(ctx, episode)
+	}
+	
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return r.CreateEpisode(ctx, episode)
+	}
+	
+	return fmt.Errorf("checking existing episode: %w", err)
+}
+
+func (r *Repository) MarkEpisodeAsPlayed(ctx context.Context, id uint, played bool) error {
+	result := r.db.WithContext(ctx).
+		Model(&models.Episode{}).
+		Where("id = ?", id).
+		Update("played", played)
+		
+	if result.Error != nil {
+		return fmt.Errorf("updating played status: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("episode with ID %d not found", id)
+	}
+	return nil
+}
+
+func (r *Repository) UpdatePlaybackPosition(ctx context.Context, id uint, position int) error {
+	result := r.db.WithContext(ctx).
+		Model(&models.Episode{}).
+		Where("id = ?", id).
+		Update("position", position)
+		
+	if result.Error != nil {
+		return fmt.Errorf("updating playback position: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("episode with ID %d not found", id)
+	}
+	return nil
+}

--- a/internal/services/episodes/repository_test.go
+++ b/internal/services/episodes/repository_test.go
@@ -1,0 +1,308 @@
+package episodes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/killallgit/player-api/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(&models.Episode{}, &models.Podcast{})
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestRepository_CreateEpisode(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	episode := &models.Episode{
+		PodcastID:   1,
+		Title:       "Test Episode",
+		Description: "Test Description",
+		AudioURL:    "https://example.com/test.mp3",
+		Duration:    3600,
+		PublishedAt: time.Now(),
+		GUID:        "test-guid-123",
+	}
+
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+	assert.NotZero(t, episode.ID)
+
+	// Verify the episode was created
+	var retrieved models.Episode
+	err = db.First(&retrieved, episode.ID).Error
+	require.NoError(t, err)
+	assert.Equal(t, episode.Title, retrieved.Title)
+	assert.Equal(t, episode.GUID, retrieved.GUID)
+}
+
+func TestRepository_UpdateEpisode(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode first
+	episode := &models.Episode{
+		PodcastID:   1,
+		Title:       "Original Title",
+		Description: "Original Description",
+		AudioURL:    "https://example.com/original.mp3",
+		Duration:    3600,
+		GUID:        "update-test-guid",
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Update the episode
+	episode.Title = "Updated Title"
+	episode.Description = "Updated Description"
+	episode.Duration = 7200
+
+	err = repo.UpdateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Verify the update
+	var retrieved models.Episode
+	err = db.First(&retrieved, episode.ID).Error
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Title", retrieved.Title)
+	assert.Equal(t, "Updated Description", retrieved.Description)
+	assert.Equal(t, 7200, retrieved.Duration)
+}
+
+func TestRepository_GetEpisodeByID(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode
+	episode := &models.Episode{
+		PodcastID:   1,
+		Title:       "Get By ID Test",
+		Description: "Test Description",
+		AudioURL:    "https://example.com/test.mp3",
+		GUID:        "get-by-id-guid",
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Get the episode by ID
+	retrieved, err := repo.GetEpisodeByID(context.Background(), episode.ID)
+	require.NoError(t, err)
+	assert.Equal(t, episode.Title, retrieved.Title)
+	assert.Equal(t, episode.GUID, retrieved.GUID)
+
+	// Test non-existent ID
+	_, err = repo.GetEpisodeByID(context.Background(), 999999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRepository_GetEpisodeByGUID(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode
+	episode := &models.Episode{
+		PodcastID:   1,
+		Title:       "Get By GUID Test",
+		Description: "Test Description",
+		AudioURL:    "https://example.com/test.mp3",
+		GUID:        "unique-guid-123",
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Get the episode by GUID
+	retrieved, err := repo.GetEpisodeByGUID(context.Background(), "unique-guid-123")
+	require.NoError(t, err)
+	assert.Equal(t, episode.Title, retrieved.Title)
+	assert.Equal(t, episode.ID, retrieved.ID)
+
+	// Test non-existent GUID
+	_, err = repo.GetEpisodeByGUID(context.Background(), "non-existent-guid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRepository_GetEpisodesByPodcastID(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create multiple episodes for the same podcast
+	podcastID := uint(1)
+	for i := 1; i <= 5; i++ {
+		episode := &models.Episode{
+			PodcastID:   podcastID,
+			Title:       fmt.Sprintf("Episode %d", i),
+			AudioURL:    fmt.Sprintf("https://example.com/episode%d.mp3", i),
+			GUID:        fmt.Sprintf("guid-%d", i),
+			PublishedAt: time.Now().Add(time.Duration(-i) * time.Hour),
+		}
+		err := repo.CreateEpisode(context.Background(), episode)
+		require.NoError(t, err)
+	}
+
+	// Get first page
+	episodes, total, err := repo.GetEpisodesByPodcastID(context.Background(), podcastID, 1, 3)
+	require.NoError(t, err)
+	assert.Len(t, episodes, 3)
+	assert.Equal(t, int64(5), total)
+
+	// Episodes should be ordered by published_at DESC
+	assert.Equal(t, "Episode 1", episodes[0].Title)
+	assert.Equal(t, "Episode 2", episodes[1].Title)
+	assert.Equal(t, "Episode 3", episodes[2].Title)
+
+	// Get second page
+	episodes, total, err = repo.GetEpisodesByPodcastID(context.Background(), podcastID, 2, 3)
+	require.NoError(t, err)
+	assert.Len(t, episodes, 2)
+	assert.Equal(t, int64(5), total)
+	assert.Equal(t, "Episode 4", episodes[0].Title)
+	assert.Equal(t, "Episode 5", episodes[1].Title)
+}
+
+func TestRepository_MarkEpisodeAsPlayed(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode
+	episode := &models.Episode{
+		PodcastID: 1,
+		Title:     "Playback Test",
+		AudioURL:  "https://example.com/test.mp3",
+		GUID:      "playback-guid",
+		Played:    false,
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Mark as played
+	err = repo.MarkEpisodeAsPlayed(context.Background(), episode.ID, true)
+	require.NoError(t, err)
+
+	// Verify
+	var retrieved models.Episode
+	err = db.First(&retrieved, episode.ID).Error
+	require.NoError(t, err)
+	assert.True(t, retrieved.Played)
+
+	// Mark as unplayed
+	err = repo.MarkEpisodeAsPlayed(context.Background(), episode.ID, false)
+	require.NoError(t, err)
+
+	err = db.First(&retrieved, episode.ID).Error
+	require.NoError(t, err)
+	assert.False(t, retrieved.Played)
+}
+
+func TestRepository_UpdatePlaybackPosition(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode
+	episode := &models.Episode{
+		PodcastID: 1,
+		Title:     "Position Test",
+		AudioURL:  "https://example.com/test.mp3",
+		GUID:      "position-guid",
+		Position:  0,
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Update position
+	err = repo.UpdatePlaybackPosition(context.Background(), episode.ID, 1234)
+	require.NoError(t, err)
+
+	// Verify
+	var retrieved models.Episode
+	err = db.First(&retrieved, episode.ID).Error
+	require.NoError(t, err)
+	assert.Equal(t, 1234, retrieved.Position)
+}
+
+func TestRepository_UpsertEpisode(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// First upsert (insert)
+	episode := &models.Episode{
+		PodcastID:   1,
+		Title:       "Upsert Test",
+		Description: "Original",
+		AudioURL:    "https://example.com/test.mp3",
+		GUID:        "upsert-guid",
+	}
+	
+	err := repo.UpsertEpisode(context.Background(), episode)
+	require.NoError(t, err)
+	originalID := episode.ID
+
+	// Second upsert (update)
+	episode2 := &models.Episode{
+		PodcastID:   1,
+		Title:       "Updated Title",
+		Description: "Updated",
+		AudioURL:    "https://example.com/updated.mp3",
+		GUID:        "upsert-guid", // Same GUID
+	}
+	
+	err = repo.UpsertEpisode(context.Background(), episode2)
+	require.NoError(t, err)
+	assert.Equal(t, originalID, episode2.ID) // Should have same ID
+
+	// Verify update
+	var retrieved models.Episode
+	err = db.First(&retrieved, originalID).Error
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Title", retrieved.Title)
+	assert.Equal(t, "Updated", retrieved.Description)
+}
+
+func TestRepository_DeleteEpisode(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+
+	// Create an episode
+	episode := &models.Episode{
+		PodcastID: 1,
+		Title:     "Delete Test",
+		AudioURL:  "https://example.com/test.mp3",
+		GUID:      "delete-guid",
+	}
+	
+	err := repo.CreateEpisode(context.Background(), episode)
+	require.NoError(t, err)
+
+	// Delete the episode
+	err = repo.DeleteEpisode(context.Background(), episode.ID)
+	require.NoError(t, err)
+
+	// Verify deletion
+	var count int64
+	db.Model(&models.Episode{}).Where("id = ?", episode.ID).Count(&count)
+	assert.Equal(t, int64(0), count)
+
+	// Try to delete non-existent episode
+	err = repo.DeleteEpisode(context.Background(), 999999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/test-episodes.sh
+++ b/test-episodes.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Test script for episode management endpoints
+
+BASE_URL="http://localhost:8080"
+API_BASE="$BASE_URL/api/v1"
+
+echo "=== Testing Episode Management API ==="
+echo ""
+
+# Test 1: Get episodes for a podcast
+echo "1. Getting episodes for podcast ID 42"
+curl -X GET "$API_BASE/podcasts/42/episodes?page=1&limit=10" \
+  -H "Content-Type: application/json" | jq '.'
+echo ""
+
+# Test 2: Sync episodes from Podcast Index
+echo "2. Syncing episodes from Podcast Index for podcast ID 42"
+curl -X POST "$API_BASE/podcasts/42/episodes/sync?limit=5" \
+  -H "Content-Type: application/json" | jq '.'
+echo ""
+
+# Test 3: Get specific episode
+echo "3. Getting episode with ID 1"
+curl -X GET "$API_BASE/episodes/1" \
+  -H "Content-Type: application/json" | jq '.'
+echo ""
+
+# Test 4: Update playback state
+echo "4. Updating playback state for episode 1"
+curl -X PUT "$API_BASE/episodes/1/playback" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "position": 1234,
+    "played": false
+  }' | jq '.'
+echo ""
+
+# Test 5: Get episode metadata
+echo "5. Getting metadata for episode 1"
+curl -X GET "$API_BASE/episodes/1/metadata" \
+  -H "Content-Type: application/json" | jq '.'
+echo ""
+
+# Test 6: Search episodes
+echo "6. Searching for episodes"
+curl -X POST "$API_BASE/episodes/search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "technology",
+    "limit": 5
+  }' | jq '.'
+echo ""
+
+echo "=== Episode Management API Tests Complete ==="


### PR DESCRIPTION
## What has changed
- Added episode fetcher service with Podcast Index API integration
- Implemented episode repository with GORM for database operations
- Created in-memory caching layer for improved performance
- Added 6 new API endpoints for episode management

## Description
This PR implements Phase 1 of the audio processing architecture by adding comprehensive episode management capabilities. The implementation includes:

- **Episode Fetcher**: Integrates with Podcast Index API to fetch episode data and metadata
- **Repository Layer**: GORM-based database operations with full CRUD support and pagination
- **Caching System**: In-memory cache with TTL and automatic expiration to reduce database load
- **API Endpoints**: RESTful endpoints for listing, syncing, and managing episode playback states
- **Comprehensive Tests**: Unit tests for all components with mocked HTTP responses and in-memory database

New endpoints:
- `GET /api/v1/podcasts/:id/episodes` - List episodes with pagination
- `POST /api/v1/podcasts/:id/episodes/sync` - Sync episodes from Podcast Index
- `GET /api/v1/episodes/:id` - Get single episode details
- `PUT /api/v1/episodes/:id/playback` - Update playback state
- `GET /api/v1/episodes/:id/metadata` - Get episode metadata
- `POST /api/v1/episodes/search` - Search episodes (placeholder)

## How to test
1. Start the server with `task serve`
2. Use the provided test script: `./test-episodes.sh`
3. Run unit tests: `task test`